### PR TITLE
Fixing ArgumentError on calling ErrorHandler.submit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ script: bundle exec rake
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libarchive-dev
+  - gem update --system
+  - gem install bundler
 
 rvm:
   - 2.1
@@ -17,8 +19,6 @@ notifications:
 
     on_success: change
     on_failure: change
-
-cache: bundler
 
 branches:
   only:

--- a/lib/opener/webservice/server.rb
+++ b/lib/opener/webservice/server.rb
@@ -223,7 +223,7 @@ module Opener
       # Submit the error to the error callback, re-raise so Rollbar can also
       # report it.
       rescue Exception => error
-        ErrorHandler.new.submit(error, request_id) if options['error_callback']
+        ErrorHandler.new.submit(error, request_id, options['error_callback']) if options['error_callback']
 
         raise error
       end

--- a/opener-webservice.gemspec
+++ b/opener-webservice.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opener-core', '~> 2.3'
   spec.add_dependency 'puma'
   spec.add_dependency 'slop', '~> 3.0'
+  spec.add_dependency 'aws-sdk-v1'
 
   spec.add_dependency 'newrelic_rpm'
   spec.add_dependency 'rollbar', '~> 1.0'

--- a/spec/opener/webservice/server_spec.rb
+++ b/spec/opener/webservice/server_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'aws-sdk-v1'
 
 describe Opener::Webservice::Server, :type => :request do
   before do
@@ -174,7 +175,7 @@ describe Opener::Webservice::Server, :type => :request do
 
   context '#analyze_async' do
     before do
-      @input = {'input' => 'Hello world', 'error_callback' => 'foo'}
+      @input = {'input' => 'Hello world', 'error_callback' => 'http://foo'}
     end
 
     example 'analyze the input and submit the output to a callback' do
@@ -187,7 +188,7 @@ describe Opener::Webservice::Server, :type => :request do
     example 'submit errors to the error callback if present' do
       Opener::Webservice::ErrorHandler.any_instance
         .should_receive(:submit)
-        .with(an_instance_of(StandardError), '123')
+        .with(an_instance_of(StandardError), '123', 'http://foo')
 
       @server.stub(:analyze).and_raise(StandardError)
 


### PR DESCRIPTION
Hi,

I found out the error_callback was never called.
A found the following error while activating JRuby error logs: 

`2016-09-14T14:13:16.906+02:00: TraceType: Exception raised: ArgumentError : wrong number of arguments calling`submit`(2 for 3)
ArgumentError: wrong number of arguments calling`submit`(2 for 3)
  analyze_async at /usr/local/rvm/gems/jruby-1.7.9/gems/opener-webservice-2.2.0/lib/opener/webservice/server.rb:226
  process_async at /usr/local/rvm/gems/jruby-1.7.9/gems/opener-webservice-2.2.0/lib/opener/webservice/server.rb:174
          async at /usr/local/rvm/gems/jruby-1.7.9/gems/opener-webservice-2.2.0/lib/opener/webservice/server.rb:332`

This PR fixed it, now Exceptions like Opener::Core::UnsupportedLanguageError: The language "ca" is not supported are sent to the error_callback URL
